### PR TITLE
CMake: update method to set C++ Standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,6 @@
 
 cmake_minimum_required (VERSION 3.15)
 
-# specify the C++ standard, C++14 for VFX Reference Platform 2020
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-
 project (aswf-sample-project
     VERSION 0.0.0
     LANGUAGES CXX C)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
   - script: |
       mkdir build
       cd build
-      cmake ..
+      cmake -DCMAKE_CXX_STANDARD=14 ..
       cmake --build .
     displayName: Build
   - script: |
@@ -44,7 +44,7 @@ jobs:
   - script: |
       mkdir build
       cd build
-      cmake ..
+      cmake -DCMAKE_CXX_STANDARD=14 ..
       cmake --build .
     displayName: Build
   - script: |
@@ -65,7 +65,7 @@ jobs:
   - script: |
       mkdir build
       cd build
-      cmake ..
+      cmake -DCMAKE_CXX_STANDARD=14 ..
       cmake --build .
     displayName: Build
   - script: |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,9 @@ target_include_directories(hello
         PRIVATE ${CMAKE_BINARY_DIR}
 )
 
+# use the C++14 standard for VFX Reference Platform 2020
+target_compile_features(hello PUBLIC cxx_std_14)
+
 # does the application run
 add_test (HelloRuns hello)
 # does it print what you expect


### PR DESCRIPTION
It is my understanding that CMAKE_CXX_STANDARD
is more targeted to toolchain files than for the projects directly:

- https://gitlab.kitware.com/cmake/cmake/issues/17146#note_299405

Whereas `target_compile_features(hello PUBLIC cxx_std_14)`,
just specify a minimum required standard,
but allow a developer or package to upgrade the standard seemlessly,
e.g. a packager may want to upgrade to C++17 for ABI-compatibility reasons.
This can be done using CMAKE_CXX_STANDARD from a toolchain file,
or from the command line:

    cmake -DCMAKE_CXX_STANDARD=17 ...

CMake will also respect the -std=<standard> flags
if specified specified from the environement variable CXXFLAGS:

    env CXXFLAGS=-std=c++17 cmake ...

or from the command line `CMAKE_CXX_FLAGS`:

    cmake -DCMAKE_CXX_FLAGS=-std=c++17 ...

One thing to be aware with this method,
is that if one wants to make sure, e.g. in CI,
that the minimum C++ standard is actually tested,
it should do so explicitely, using one of the aforementioned methods.
The azure-pipelines.yml has been updated for this reason.